### PR TITLE
Event subscriber

### DIFF
--- a/sms_rule_based.services.yml
+++ b/sms_rule_based.services.yml
@@ -11,5 +11,10 @@ services:
     arguments: ['@container.namespaces', '@cache.discovery', '@module_handler']
 
   # Override the default sms_provider alias.
-  sms_provider:
-    alias: sms_provider.rule_based
+#  sms_provider:
+#    alias: sms_provider.rule_based
+
+  sms.rule_based_processor:
+    class: Drupal\sms_rule_based\EventSubscriber\RuleBasedSmsMessageProcessor
+    tags:
+      - { name: event_subscriber }

--- a/src/EventSubscriber/RuleBasedSmsMessageProcessor.php
+++ b/src/EventSubscriber/RuleBasedSmsMessageProcessor.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Drupal\sms_rule_based\EventSubscriber;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Drupal\sms\Event\SmsMessageEvent;
+use Drupal\sms\Message\SmsMessageInterface;
+use Drupal\sms\Entity\SmsGateway;
+use Drupal\sms_rule_based\Entity\SmsRoutingRuleset;
+
+class RuleBasedSmsMessageProcessor implements EventSubscriberInterface {
+
+  public function ruleBased(SmsMessageEvent $event) {
+    $result = [];
+
+    foreach ($event->getMessages() as &$sms) {
+      $routing = $this->routeMessage($sms);
+
+      $base = $sms instanceof SmsMessageInterface ? $sms->createDuplicate() : (clone $sms);
+      $base->removeRecipients($sms->getRecipients());
+
+      foreach ($routing['routes'] as $gateway_id => $numbers) {
+        if ($numbers) {
+          $new = $base instanceof SmsMessageInterface ? $base->createDuplicate() : (clone $base);
+          $new->addRecipients($numbers);
+          if ($gateway_id != '__default__') {
+            $new->setGateway(SmsGateway::load($gateway_id));;
+          }
+
+          $result[] = $new;
+        }
+      }
+    }
+
+    $event->setMessages($result);
+  }
+
+  /**
+   * Uses the rule-based routing service to route recipients through SMS gateways.
+   *
+   * @param \Drupal\sms\Message\SmsMessageInterface $sms
+   *
+   * @return array
+   */
+  protected function routeMessage(SmsMessageInterface $sms) {
+    if (\Drupal::config('sms_rule_based.settings')->get('enable_rule_based_routing')) {
+      // Get rulesets and sort them in order so the first ruleset to match is
+      // implemented.
+      /** @var \Drupal\sms_rule_based\Entity\SmsRoutingRuleset[] $rulesets */
+      $rulesets = SmsRoutingRuleset::loadMultiple();
+      // @todo this sorting needs to be checked.
+      uasort($rulesets, function(SmsRoutingRuleset $ruleset1, SmsRoutingRuleset $ruleset2) {
+        $weight1 = $ruleset1->get('weight');
+        $weight2 = $ruleset2->get('weight');
+        return ($weight1 > $weight2) ? 1 : ($weight1 == $weight2 ? 0 : -1);
+      });
+      $routing = \Drupal::service('sms_rule_based.sms_router')->routeSmsRecipients($sms, $rulesets);
+    }
+    else {
+      $routing = [
+        'routes' => [
+          '__default__' => $sms->getRecipients(),
+        ],
+      ];
+    }
+    return $routing;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() {
+    $events['sms.message.preprocess'][] = ['ruleBased', 1025];
+    return $events;
+  }
+
+}

--- a/src/Form/SmsRoutingRulesetForm.php
+++ b/src/Form/SmsRoutingRulesetForm.php
@@ -91,7 +91,7 @@ class SmsRoutingRulesetForm extends EntityForm {
       '#type' => 'select',
       '#title' => t('Gateway'),
       '#options' => $options,
-      '#default_value' => $gateway ?: \Drupal::service('sms_provider.rule_based')->getDefaultGateway()->id(),
+      '#default_value' => $gateway ?: \Drupal::service('sms_provider')->getDefaultGateway()->id(),
     );
 
     $form['weight'] = array(

--- a/src/Form/SmsRoutingRulesetListForm.php
+++ b/src/Form/SmsRoutingRulesetListForm.php
@@ -147,7 +147,7 @@ class SmsRoutingRulesetListForm extends DraggableListBuilder {
    * @return \Drupal\sms_rule_based\Provider\RuleBasedSmsProvider
    */
   protected function smsProvider() {
-    return \Drupal::service('sms_provider.rule_based');
+    return \Drupal::service('sms_provider');
   }
 
 }

--- a/src/Tests/RuleBasedRoutingIntegrationTest.php
+++ b/src/Tests/RuleBasedRoutingIntegrationTest.php
@@ -180,7 +180,7 @@ class RuleBasedRoutingIntegrationTest extends WebTestBase {
     $ruleset3->save();
 
     $sms_message = new SmsMessage('sender', [$number1, $number2, $number3], 'test message');
-    \Drupal::service('sms_provider.rule_based')->send($sms_message);
+    \Drupal::service('sms_provider')->send($sms_message);
 
     // Verify correct routing. Each gateway should receive exactly one message
     // to the specific recipient.
@@ -220,7 +220,7 @@ class RuleBasedRoutingIntegrationTest extends WebTestBase {
     $messages4 = $this->getTestMessages($gateway4);
     $this->assertEqual(0, count($messages4));
     $sms_message = new SmsMessage('sender', [$number1, $number2, $number3], 'test message', [], 6);
-    \Drupal::service('sms_provider.rule_based')->send($sms_message);
+    \Drupal::service('sms_provider')->send($sms_message);
     $messages4 = $this->getTestMessages($gateway4);
     $this->assertEqual(1, count($messages4));
     $this->assertEqual($messages4[0]->getRecipients(), [$number1, $number2, $number3]);
@@ -266,7 +266,7 @@ class RuleBasedRoutingIntegrationTest extends WebTestBase {
     $ruleset2->save();
     $this->resetTestMessages();
     $sms_message = new SmsMessage('sender', [$number], 'test message', []);
-    \Drupal::service('sms_provider.rule_based')->send($sms_message);
+    \Drupal::service('sms_provider')->send($sms_message);
     $this->assertEqual(1, count($this->getTestMessages($gateway1)));
     $this->assertEqual(0, count($this->getTestMessages($gateway2)));
 
@@ -274,7 +274,7 @@ class RuleBasedRoutingIntegrationTest extends WebTestBase {
     $ruleset1->set('weight', 1)->save();
     $this->resetTestMessages();
     $sms_message = new SmsMessage('sender', [$number], 'test message', []);
-    \Drupal::service('sms_provider.rule_based')->send($sms_message);
+    \Drupal::service('sms_provider')->send($sms_message);
     $this->assertEqual(0, count($this->getTestMessages($gateway1)));
     $this->assertEqual(1, count($this->getTestMessages($gateway2)));
   }


### PR DESCRIPTION
added a consumer for event subscriber

> disable the provider.
> add a event subscriber processor.
> implemented a callback for 'sms.message.preprocessor', but it should really use 'sms.message.gateway'.
